### PR TITLE
Improve arguments parsing with schema list and "strict" parsing mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ function safeFunc() {
       }
     ]);
   
-  options = args.options || { some: 'value' };
+  var options = args.options || { some: 'value' };
   
   // some stuff
   if (args.id) {

--- a/README.md
+++ b/README.md
@@ -51,7 +51,69 @@ same key as was given in the schema. You can inspect the returned object to more
 obtain the parsed value without having to duplicate the HAVE.js parsing logic in your code
 to extract them.
 
-See [@wmakeev PR](https://github.com/chakrit/have/pull/4) for an example.
+```js
+var have = require('have');
+
+function safeFunc(id, options, callback) {
+  var args = have(arguments,
+    { id       : 'string or number'
+    , options  : 'optional object'
+    , callback : 'function'
+    });
+  
+  options = args.options || { some: 'value' };
+  
+  // some stuff
+  someDb.loadById(args.id, options, args.callback);
+};
+```
+
+For a more careful argument names parsing you can pass several schema.
+
+```js
+var have = require('have');
+
+function safeFunc() {
+  var args = have(arguments,
+    [ { id       : 'string or number'
+      , options  : 'optional object'
+      , callback : 'function'
+      }
+    , { query    : 'object'
+      , options  : 'optional object'
+      , callback : 'function'
+      }
+    ]);
+  
+  options = args.options || { some: 'value' };
+  
+  // some stuff
+  if (args.id) {
+    someDb.loadById(args.id, options, args.callback);
+  } else {
+    someDb.find(args.query, options, args.callback);    
+  }
+};
+```
+
+And use "strict" mode to fail for those extra arguments that do not match the schema.
+
+```js
+var have = require('have');
+
+function safeFunc(id, options, callback) {
+  var args = have.strict(arguments,
+    { id       : 'string or number'
+    , options  : 'optional object'
+    , callback : 'function'
+    });
+  
+  // some stuff
+};
+
+// This throws an AssertionError: Wrong argument "foo"
+safeFunc('id', { key: 'value' }, cb, 'foo') 
+```
 
 # SOFT ASSERTS
 

--- a/example.js
+++ b/example.js
@@ -4,7 +4,7 @@ var assert = require('assert')
 
 
 function withHave(id, arr, opts, callback) {
-  have(arguments,
+  var args = have(arguments,
     { id: 'str or num'
     , arr: 'str or str array'
     , opts: 'optional obj'
@@ -12,9 +12,9 @@ function withHave(id, arr, opts, callback) {
 
   if (!(arr instanceof Array)) { arr = [arr]; }
 
-  if (typeof opts === 'function') {
-    callback = opts;
+  if (!args.opts) {
     opts = { x: 'some default value' };
+    callback = args.callback;
   }
 
   // logic...

--- a/have.js
+++ b/have.js
@@ -120,14 +120,16 @@ module.exports = (function(undefined) {
       , parsedArgs = { };
 
     for (argName in schema) {
-      if (ensure(argName, schema[argName], args[idx], assert)) {
+      if (schema.hasOwnProperty(argName)) {
+        if (ensure(argName, schema[argName], args[idx], assert)) {
           parsedArgs[argName] = args[idx];
           idx++;
+        }
       }
     }
 
     return parsedArgs;
-  };
+  }
 
   // configuration
   have.assert = function(assert_) {

--- a/have.js
+++ b/have.js
@@ -3,7 +3,6 @@
 module.exports = (function(undefined) {
 
   var assert = require('assert')
-    , fmt    = require('util').format
     , log    = function() { } // require('util').log; // disabled
     ;
 
@@ -45,8 +44,7 @@ module.exports = (function(undefined) {
       memberType = match[2];
       ensure(argName, memberType, value, softAssert);
 
-      check(valid, fmt("%s argument is neither a %s nor %s",
-        argName, match[1], match[2]));
+      check(valid, argName + " argument is neither a " + match[1] + " nor " + match[2]);
       return true;
     }
 
@@ -64,7 +62,7 @@ module.exports = (function(undefined) {
         ensure(argName, memberType, value[i], softAssert);
 
         if (!valid) {
-          check(false, fmt("%s element is falsy or not a %s", argName, memberType));
+          check(false, argName + " element is falsy or not a " + memberType);
           return false;
         }
       }
@@ -106,7 +104,7 @@ module.exports = (function(undefined) {
         valid = false; break;
     }
 
-    check(valid, fmt("%s argument is not %s", argName, argType));
+    check(valid, argName + " argument is not " + argType);
     return true;
   }
 


### PR DESCRIPTION
For a more careful argument names parsing you can pass several schema.

``` js
var have = require('have');

function safeFunc() {
  var args = have(arguments,
    [ { id       : 'string or number'
      , options  : 'optional object'
      , callback : 'function'
      }
    , { query    : 'object'
      , options  : 'optional object'
      , callback : 'function'
      }
    ]);

  var options = args.options || { some: 'value' };

  // some stuff
  if (args.id) {
    someDb.loadById(args.id, options, args.callback);
  } else {
    someDb.find(args.query, options, args.callback);    
  }
};
```

And use "strict" mode to fail for those extra arguments that do not match the schema.

``` js
var have = require('have');

function safeFunc(id, options, callback) {
  var args = have.strict(arguments,
    { id       : 'string or number'
    , options  : 'optional object'
    , callback : 'function'
    });

  // some stuff
};

// This throws an AssertionError: Wrong argument "foo"
safeFunc('id', { key: 'value' }, cb, 'foo') 
```

And improve tests coverage to 100%
