### PR TITLE
Ability to define custom matchers and override built-in

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ function safeFunc() {
 };
 ```
 
-And use "strict" mode to fail for those extra arguments that do not match the schema.
+Use "strict" mode to fail for those extra arguments that do not match the schema.
 
 ```js
 var have = require('have');
@@ -113,6 +113,31 @@ function safeFunc(id, options, callback) {
 
 // This throws an AssertionError: Wrong argument "foo"
 safeFunc('id', { key: 'value' }, cb, 'foo') 
+```
+
+And, of course, you can define your own matchers and override built-in.
+
+```js
+var have = require('have').with(
+  { 'MyClass|mycls': function (myClass) {
+    return myClass instanceof MyClass
+  }
+  , 's|str|string': function (str) {
+      return typeof str === 'string' && str.length
+    } 
+  });
+
+function safeFunc(myClass, msg) {
+  have(arguments,
+    { myClass : 'MyClass'
+    , msg     : 'optional string'
+    });
+  
+  // some stuff
+};
+
+// This throws an AssertionError: myClass argument is not MyClass
+safeFunc({}, 'hello') 
 ```
 
 # SOFT ASSERTS
@@ -155,9 +180,13 @@ BSD (if you don't like BSD, just contact me)
 
 # CHANGELOG
 
+#### v0.4.0
+
+* Add support for custom arguments matchers
+
 #### v0.3.0
 
-* (credit: @wmakeev) The function now returns parsed arguments as a hash object.
+* The function now returns parsed arguments as a hash object.
 
 #### v0.2.3
 
@@ -178,6 +207,6 @@ Pull requests and feature suggestions totally welcome.
 
 ```
     40	Chakrit Wichian
-     2	Makeev Vitaliy
+     3	Makeev Vitaliy
      1	Edmond Meinfelder
 ```

--- a/have.js
+++ b/have.js
@@ -10,22 +10,57 @@ module.exports = (function(undefined) {
     , OR_RX  = /^(.+) or (.+)$/i
     , OPT_RX = /^opt(ional)? (.+)$/i;
 
+  // tools functions
+
+  function assign () {
+    var args = Array.prototype.slice.call(arguments, 0)
+      , target = args[0]
+      , source = args.slice(1);
+
+    for (var i = 0, len = source.length; i < len; i++) {
+      for (var p in source[i]) {
+        if (source[i].hasOwnProperty(p)) {
+          target[p] = source[i][p];
+        }
+      }
+    }
+
+    return target;
+  }
+
+  // { 's|str': val1 } -> { 's': val1, 'str': val1 }
+  function unfoldTypes (types) {
+    var unfolded = {};
+    for (var p in types) {
+      if (types.hasOwnProperty(p)) {
+        var variants = p.split(/\|/);
+        for (var i = 0, len = variants.length; i < len; i++) {
+          unfolded[variants[i]] = types[p]
+        }
+      }
+    }
+    return unfolded;
+  }
+
   // core recursive check
-  function ensure(argName, argType, value, check) {
+  function ensure(types, argName, argType, value, check) {
     var memberType = null
       , valid      = true
       , reason     = null
       , match      = null
       , i          = 0;
 
-    function softAssert(cond, reason_) { if (!(valid = cond)) reason = reason_; }
+    function softAssert(cond, reason_) {
+      if (!(valid = cond)) reason = reason_;
+    }
+
     function logMatch() { log(match[0]); }
 
     if (match = argType.match(OPT_RX)) {
       logMatch();
       memberType = match[2];
 
-      ensure(argName, memberType, value, softAssert);
+      ensure(types, argName, memberType, value, softAssert);
 
       // optional is consumed if it match or a null/undefined is given.
       return valid ||
@@ -36,21 +71,22 @@ module.exports = (function(undefined) {
     if (match = argType.match(OR_RX)) {
       logMatch();
       memberType = match[1];
-      ensure(argName, memberType, value, softAssert);
+      ensure(types, argName, memberType, value, softAssert);
 
       if (valid) return true;
       valid = true; // reset previous softAssert
 
       memberType = match[2];
-      ensure(argName, memberType, value, softAssert);
+      ensure(types, argName, memberType, value, softAssert);
 
-      check(valid, argName + " argument is neither a " + match[1] + " nor " + match[2]);
+      check(valid, argName + " argument is neither a " + match[1] +
+        " nor " + match[2]);
       return true;
     }
 
     if (match = argType.match(ARR_RX)) {
       logMatch();
-      ensure(argName, 'array', value, softAssert);
+      ensure(types, argName, 'array', value, softAssert);
 
       if (!valid) {
         check(false, reason);
@@ -59,7 +95,7 @@ module.exports = (function(undefined) {
 
       memberType = match[1];
       for (i = 0; i < value.length; i++) {
-        ensure(argName, memberType, value[i], softAssert);
+        ensure(types, argName, memberType, value[i], softAssert);
 
         if (!valid) {
           check(false, argName + " element is falsy or not a " + memberType);
@@ -72,43 +108,15 @@ module.exports = (function(undefined) {
 
     // atom types
     log(argType);
-    switch(argType) {
-
-      // basic types
-      case 's': case 'str': case 'string':
-        valid = typeof value === 'string'; break;
-
-      case 'n': case 'num': case 'number':
-        valid = typeof value === 'number'; break;
-
-      case 'b': case 'bool': case 'boolean':
-        valid = typeof value === 'boolean'; break;
-
-      case 'f': case 'fun': case 'func': case 'function':
-        valid = typeof value === 'function'; break;
-
-      case 'a': case 'arr': case 'array':
-        valid = value instanceof Array; break;
-
-      case 'o': case 'obj': case 'object':
-        valid = value && typeof value === 'object'; break;
-
-      // built-in types
-      case 'r': case 'rx': case 'regex': case 'regexp':
-        valid = value && value instanceof RegExp; break;
-
-      case 'd': case 'date': // TODO: case 't': case 'time': case 'datetime': // ?
-        valid = value && value instanceof Date; break;
-
-      default:
-        valid = false; break;
-    }
+    valid = types.hasOwnProperty(argType)
+      ? types[argType](value)
+      : types.default(value);
 
     check(valid, argName + " argument is not " + argType);
     return true;
   }
 
-  function ensureArgs(args, schema, strict) {
+  function ensureArgs(args, schema, types, strict) {
     if (!(args && typeof args === 'object' && 'length' in args))
       throw new Error('have() called with invalid arguments list');
     if (!(schema && typeof schema === 'object'))
@@ -125,7 +133,7 @@ module.exports = (function(undefined) {
         throw new Error('have() called with empty schema list');
 
       for (i = 0, len = schema.length; i < len; i++) {
-        ensureResults[i] = ensureArgs(args, schema[i], strict);
+        ensureResults[i] = ensureArgs(args, schema[i], types, strict);
       }
 
       ensureResults.sort(function (a, b) {
@@ -142,9 +150,8 @@ module.exports = (function(undefined) {
     } else {
       for (var argName in schema) {
         if (schema.hasOwnProperty(argName)) {
-          var ensured = ensure(argName, schema[argName], args[argIndex], function (cond, fail_) {
-            if (!cond) fail = fail_;
-          });
+          var ensured = ensure(types, argName, schema[argName], args[argIndex],
+            function (cond, fail_) { if (!cond) fail = fail_; });
           if (fail) break;
           if (ensured) {
             parsedArgs[argName] = args[argIndex];
@@ -155,7 +162,9 @@ module.exports = (function(undefined) {
 
       if (strict && !fail && argIndex < args.length) {
         var argStr = args[argIndex].toString();
-        fail = 'Wrong argument "' + (argStr.length > 15 ? argStr.substring(0, 15) + '..' : argStr) + '"';
+        fail = 'Wrong argument "' + (argStr.length > 15
+            ? argStr.substring(0, 15) + '..'
+            : argStr) + '"';
       }
 
       return {
@@ -168,7 +177,7 @@ module.exports = (function(undefined) {
 
   // exports
   function have(args, schema, strict) {
-    var res = ensureArgs(args, schema, strict);
+    var res = ensureArgs(args, schema, this.types, strict);
     assert(!res.fail, res.fail);
     return res.parsedArgs;
   }
@@ -179,10 +188,41 @@ module.exports = (function(undefined) {
   };
 
   have.strict = function(args, schema) {
-    return have(args, schema, true);
+    return this(args, schema, true);
   };
 
-  return have;
+  have.types = {};
+
+  have.with = function (types) {
+    if (!(types && typeof types === 'object')) {
+      throw new Error('types argument must be an object')
+    }
+    var _have = function () { return have.apply(_have, arguments) };
+    _have.assert = have.assert;
+    _have.strict = have.strict;
+    _have.with = have.with;
+    _have.types = assign({}, unfoldTypes(this.types), unfoldTypes(types));
+
+    return _have;
+  };
+
+  return have.with(
+    // basic types
+    { 's|str|string': function (value) { return typeof value === 'string'; }
+    , 'n|num|number': function (value) { return typeof value === 'number'; }
+    , 'b|bool|boolean': function (value) { return typeof value === 'boolean'; }
+    , 'f|fun|func|function': function (value) {
+      return typeof value === 'function'; }
+    , 'a|arr|array': function (value) { return value instanceof Array }
+    , 'o|obj|object': function (value) {
+      return value && typeof value === 'object'; }
+
+    // built-in types
+    , 'r|rx|regex|regexp': function (value) {
+      return value && value instanceof RegExp }
+    , 'd|date': function (value) { return value && value instanceof Date }
+    , 'default': function () { return false; } }
+  );
 
 })();
 

--- a/have.js
+++ b/have.js
@@ -199,7 +199,7 @@ module.exports = (function(undefined) {
     }
     var _have = function () { return have.apply(_have, arguments) };
     _have.assert = have.assert;
-    _have.strict = have.strict;
+    _have.strict = have.strict.bind(_have);
     _have.with = have.with;
     _have.types = assign({}, unfoldTypes(this.types), unfoldTypes(types));
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "have",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Have your arguments, and validate it too. -- Slick arguments validator for all your js functions.",
   "main": "have.js",
   "scripts": {

--- a/test.js
+++ b/test.js
@@ -70,7 +70,7 @@
         });
 
         it('should *not* throws (strict mode)', function() {
-          assert.doesNotThrow(function() { have.strict.apply(have, args); });
+          assert.doesNotThrow(function() { have.strict.apply(null, args); });
         });
       });
     }); // empty schema
@@ -81,7 +81,7 @@
         it('should throws if ' + description, function() {
           assert.throws(function() {
             strict
-              ? have.strict.call(have, args[0], args[1])
+              ? have.strict.call(null, args[0], args[1])
               : have.call(null, args[0], args[1]);
           }, args[2]);
         });
@@ -93,7 +93,7 @@
         it('should *not* throws if ' + description, function() {
           assert.doesNotThrow(function() {
             strict
-              ? have.strict.call(have, args[0], args[1])
+              ? have.strict.call(null, args[0], args[1])
               : have.call(null, args[0], args[1]);
           }, args[2]);
         });
@@ -104,7 +104,7 @@
       for (var description in cases) (function(description, args) {
         describe('resulting object when ' + description, function() {
           var result = strict
-            ? have.strict.call(have, args[0], args[1])
+            ? have.strict.call(null, args[0], args[1])
             : have.call(null, args[0], args[1]);
           var expected = args[2];
 

--- a/test.js
+++ b/test.js
@@ -70,7 +70,7 @@
         });
 
         it('should *not* throws (strict mode)', function() {
-          assert.doesNotThrow(function() { have.strict.apply(null, args); });
+          assert.doesNotThrow(function() { have.strict.apply(have, args); });
         });
       });
     }); // empty schema
@@ -81,8 +81,8 @@
         it('should throws if ' + description, function() {
           assert.throws(function() {
             strict
-              ? have.strict.call(this, args[0], args[1])
-              : have.call(this, args[0], args[1]);
+              ? have.strict.call(have, args[0], args[1])
+              : have.call(null, args[0], args[1]);
           }, args[2]);
         });
       })(description, cases[description]);
@@ -93,8 +93,8 @@
         it('should *not* throws if ' + description, function() {
           assert.doesNotThrow(function() {
             strict
-              ? have.strict.call(this, args[0], args[1])
-              : have.call(this, args[0], args[1]);
+              ? have.strict.call(have, args[0], args[1])
+              : have.call(null, args[0], args[1]);
           }, args[2]);
         });
       })(description, cases[description]);
@@ -104,8 +104,8 @@
       for (var description in cases) (function(description, args) {
         describe('resulting object when ' + description, function() {
           var result = strict
-            ? have.strict.call(this, args[0], args[1])
-            : have.call(this, args[0], args[1]);
+            ? have.strict.call(have, args[0], args[1])
+            : have.call(null, args[0], args[1]);
           var expected = args[2];
 
           for (var key in expected) (function(key) {
@@ -180,7 +180,7 @@
           , 'date argument is a string'              : [['' + new Date()], SCHEMA, /one/i]
           });
 
-        var args = [new Date()]
+        var args = [new Date()];
 
         checkNotThrows({ 'date argument is given correctly': [args, SCHEMA] });
         checkResult({ 'date argument': [args, SCHEMA, { one: args[0] }] });
@@ -475,6 +475,53 @@
         checkResult(cases, true);
       })
     }); // schema list
+
+    describe('with custom type checkers', function () {
+      function FooType () {
+        this.name = 'FooType'
+      }
+
+      assert.throws(function() {
+        have.with(null);
+      }, 'types argument must be an object');
+
+      var myHave = have.with(
+        { 'Name': function (name) {
+            return name && typeof name === 'string' && name.length > 1 &&
+              name.substring(0, 1) === name.substring(0, 1).toUpperCase()
+          }
+        , 'FooType|foo': function (type) {
+            return type instanceof FooType
+          }
+        });
+
+      var SCHEMA1 = { str: 'str', name: 'opt num or Name', foo: 'FooType' };
+      var fooType = new FooType();
+      var result;
+
+      result = myHave.call(null, ['', 'Jake', fooType], SCHEMA1);
+      assert.strictEqual(result.name, 'Jake');
+      assert.strictEqual(result.foo, fooType);
+
+      assert.throws(function() {
+        myHave.call(null, ['str', 10, {}], SCHEMA1);
+      }, 'foo argument is not FooType');
+
+      var SCHEMA2 = { str: 'str', name: 'opt num or Name', foo: 'foo' };
+      var myHave2 = myHave.with(
+        { 's|str|string': function (str) {
+            return typeof value === 'string' && s.length
+          }
+        });
+
+      assert.doesNotThrow(function() {
+        myHave.call(null, ['', 'Jake', fooType], SCHEMA2);
+      });
+
+      assert.throws(function() {
+        myHave2.call(null, ['', 'Jake', fooType], SCHEMA2);
+      }, 'str argument is not str');
+    })
   });
 
 })();


### PR DESCRIPTION
``` js
var have = require('have').with(
  { 'MyClass|mycls': function (myClass) {
    return myClass instanceof MyClass
  }
  , 's|str|string': function (str) {
      return typeof str === 'string' && str.length
    } 
  });

function safeFunc(myClass, msg) {
  have(arguments,
    { myClass : 'MyClass'
    , msg     : 'optional string'
    });

  // some stuff
};

// This throws an AssertionError: myClass argument is not MyClass
safeFunc({}, 'hello') 
```
